### PR TITLE
Allow overriding the level.

### DIFF
--- a/winex.coffee
+++ b/winex.coffee
@@ -111,7 +111,7 @@ clientIp = (req) ->
 #
 # @param        [Object] winstonLogger Winston logger.
 # @param        [Object] classMeta     Extra meta for every log call.
-# @param        [Object] opts          Extra meta for every log call.
+# @param        [Object] opts          Extra options for every log call.
 # @config opts  [Object] nop           Use NOP logger instead.
 factory = (winstonLogger, classMeta = {}, opts = {}) ->
   useNop = opts.nop is true
@@ -128,6 +128,7 @@ factory = (winstonLogger, classMeta = {}, opts = {}) ->
 
       # Patch in incoming data.
       @addReq   opts.req    if opts.req
+      @addRes   opts.res    if opts.res
       @addError opts.error  if opts.error
 
     # Default request type if not specified.
@@ -158,6 +159,9 @@ factory = (winstonLogger, classMeta = {}, opts = {}) ->
             level = "warning"
           if res.statusCode >= 500
             level = "error"
+
+          # Allow overriding the level.
+          level = log.level if log.level?
 
           log.addRes res
           log[level] "request"

--- a/winex.js
+++ b/winex.js
@@ -192,6 +192,9 @@
             if (res.statusCode >= 500) {
               level = "error";
             }
+            if (log.level != null) {
+              level = log.level;
+            }
             log.addRes(res);
             return log[level]("request");
           };


### PR DESCRIPTION
@nanek 

Neodarwin has always served, and logged, static files in development, and I have always found it annoying because it clogs up the console with unnecessary messages. My intent with this change is to set the log level to verbose when process.env is development in Neodarwin and a static file is being served.